### PR TITLE
chore: remove a commented-out print

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -14,7 +14,6 @@ class AppDelegate: NSObject,NSApplicationDelegate {
     func applicationWillTerminate(_ notification: Notification) {
         Task {
             await ADB.run(arguments: [.kill])
-//            print("adb killed")
         }
     }
 }


### PR DESCRIPTION
It's a minor cleanup, removes a commented-out print statement that was left in the codebase.